### PR TITLE
Revert "Bump actions/setup-go from 3.5.0 to 4.0.0"

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -15,7 +15,7 @@ jobs:
     
     steps:
       - name: Setup go
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # https://github.com/actions/setup-go/releases/tag/v4.0.0
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # https://github.com/actions/setup-go/releases/tag/v3.5.0
         with:
           go-version: ${{ matrix.go-version }}
       


### PR DESCRIPTION
Reverts NeXTLinux/go-version#3